### PR TITLE
Update slack signup request url

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ in the channel `#package-maintenance` in order to continue conversations beyond 
 All the contributors are expected to follow the [Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md)
 of the Node.js project.
 
-To join on slack you have to [send a request](https://www.nodeslackers.com/) and wait
+To join on slack you have to [send a request](http://www.nodeslackers.com/) and wait
 to be accepted: it is a manual workflow, so it could take some days (we are working to help improve this).
 
 ## Current Project Team Members

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ about this initiative in the article:
 
 We encourage participation from members across the Node.js and JavaScript
 ecosystem. Feel free to join schedule meetings and participate
-in the issues within the repository. 
+in the issues within the repository.
 
 ## How to Join
 


### PR DESCRIPTION
## What is the change?

The `https` version of this url does not work, but the `http` version works.

## ~New Dependancies~

## Feels

![reaction - Ohhhh...](https://media.giphy.com/media/Dg4bJOS0OpyzC/giphy.gif)