### PR TITLE
feat(members): add Jacopo Daeli

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -86,3 +86,4 @@
 * James George ([@jamesgeorge007](https://www.github.com/jamesgeorge007))
 * Gabriel Schulhof ([@gabrielschulhof](https://www.github.com/gabrielschulhof))
 * Minh Nguyen ([@truongminh](https://github.com/truongminh))
+* Jacopo Daeli ([@JacopoDaeli](https://github.com/JacopoDaeli))


### PR DESCRIPTION
Adding myself to the project. I am lead software engineer at [GoDaddy](https://github.com/godaddy) where we extensively use Node.js for building our platform and services. I'd love to contribute to maintaining Node.js and it's packages.