### PR TITLE
+ Survey: version question

### DIFF
--- a/pilots/SURVEY.md
+++ b/pilots/SURVEY.md
@@ -12,6 +12,7 @@ These are the basic questions to start with:
 + What are the most frequent problems?
 + What would you like to do to us?
 + What problems are due to your dependencies?
++ How do you discover if a new version of your dependencies are available and what changes are made?
 + Are your dependencies need of help? 
 + Do you have to contribute to your dependencies? Do you establish a good communication channel?
 


### PR DESCRIPTION
Usually use a [VSCode plugin](https://marketplace.visualstudio.com/items?itemName=pflannery.vscode-versionlens) to see if there are new versions in my package.json.  Unfortunately, it doesn't list `pre-release` or `next` versions which can [hide needed fixes](https://github.com/videojs/video.js/issues/5771).

Also, repos are scattered how they summarize changes.  Some do `CHANGELOG.md`, some write long descriptions in their release post, some just list the PR titles, & a few still use `README` or blogs.