### PR TITLE
Rename "best-effort" to "ad-hoc"

### DIFF
--- a/docs/drafts/PACKAGE-SUPPORT.md
+++ b/docs/drafts/PACKAGE-SUPPORT.md
@@ -196,7 +196,7 @@ The standardized support identifiers are as follows:
 | Value | Description |
 |-------|-------------|
 | `none`         | Don't expect a response, the package is not being actively maintained
-| `ad-hoc`       | The maintainer is interested in fixing/discussing issues, however, there should be no expectation on response times. If and when the maintainer has time they may respond.
+| `ad-hoc`       | The maintainer is interested in fixing/discussing issues. However, there should be no expectation on response times. If and when the maintainer has time, they may respond.
 | `regular-X`    | There are dedicated resources who regularly maintain the package, expected response time is X days or less for a "we read your issue" response. Further work will depend on prioritization of the issue by the maintainer team.
 | `24-7`         | There are dedicated resources who regularly maintain the package and they are available 24/7. You can expect to be able to contact the maintainers and get an initial response with 6 hours.
 

--- a/docs/drafts/PACKAGE-SUPPORT.md
+++ b/docs/drafts/PACKAGE-SUPPORT.md
@@ -60,7 +60,7 @@ The default for packages created by individuals for their own use should be:
           "node": "none"
         },
         "response": {
-          "type": "best-effort",
+          "type": "ad-hoc",
           "paid": false,
           "contact": {
             "name": "Volunteers",
@@ -153,7 +153,7 @@ For example:
 ```json
 response: [
   {
-    "type": "best-effort",
+    "type": "ad-hoc",
     "paid": false,
     "contact": {
       "name": "Volunteers",
@@ -196,7 +196,7 @@ The standardized support identifiers are as follows:
 | Value | Description |
 |-------|-------------|
 | `none`         | Don't expect a response, the package is not being actively maintained
-| `best-effort`  | The maintainer is interested in fixing/discussing issues, however, there should be no expectation on response times. If and when the maintainer has time they may respond.
+| `ad-hoc`       | The maintainer is interested in fixing/discussing issues, however, there should be no expectation on response times. If and when the maintainer has time they may respond.
 | `regular-X`    | There are dedicated resources who regularly maintain the package, expected response time is X days or less for a "we read your issue" response. Further work will depend on prioritization of the issue by the maintainer team.
 | `24-7`         | There are dedicated resources who regularly maintain the package and they are available 24/7. You can expect to be able to contact the maintainers and get an initial response with 6 hours.
 


### PR DESCRIPTION
I noticed the current draft of the support format uses "best effort", a problematic legalism common in contracts that's usually taken to mean rather the opposite of what the group seems to mean here. I recommend replacing "best effort" with something else, and propose "ad hoc" as a starting point. I also considered "impromptu", "informal", "sporadic", and "casual". I'd rather avoid Latin, but couldn't find an earthy Anglo-Saxon synonym.

"Best efforts" and the like are strongly discouraged usages in legal drafting. See, for example, [a post from Ken Adams](https://www.adamsdrafting.com/what-does-best-efforts-mean/), a well known drafting specialist.

When lawyers use them anyway, the question often becomes how much pain, inconvenience, and expense the party that promised best efforts has to endure to get the job done. Since "best" is a superlative, the expectation is that in nearly every normal case, the job will get done. Not that the job will get done if one feels like it, has time, takes an interest, and so on.

I have a broader, related concern about the way that a standard like this could put pressure on already stretched maintainers to make essentially gratuitous support SLA commitment to all comers. But as much as I care about that more than this word-choice issue, I'd prefer to table the broader issue for now. It's more than I can bite off right now.