### PR TITLE
doc: remove @lance from list of members

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -31,7 +31,6 @@
 * Xin Du ([@clarkdo](https://github.com/clarkdo))
 * Alexey Pyltsyn ([@lex111](https://github.com/lex111))
 * Manuel Spigolon ([@eomm](https://github.com/Eomm))
-* Lance Ball ([@lance](https://github.com/lance))
 * Zied CHOUK ([@ZiedCHOUK](https://github.com/ZiedCHOUK))
 * James Youngs ([@sidhuko](https://github.com/sidhuko))
 * Rob Simpson ([@pertrai1](https://github.com/pertrai1))


### PR DESCRIPTION
I have not been actively participating in this working group since my day to day work has my focus shifted elsewhere. It seems best for me to remove myself from the list.