### PR TITLE
Issue/309 docs table of contents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,4 @@ As Node.js and most of the packages in the ecosystem are predominantly hosted on
 1. [Versioning](./versioning.md)
 1. [Support (draft)](./drafts/PACKAGE-SUPPORT.md)
 1. [Governance (draft)](./drafts/governance.md)
+1. [Tools (draft)](./drafts/tools.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,23 @@
 # DOCS
 
-This is the location for documentation, guide and other
-information developed by the package-maintenance
-team.
+This is the location for documentation, guides and other information developed by the package-maintenance team.  It is intended to provide as a set of resources and references for all package developers and maintainers. 
+
+## Goals and Objectives
+The goal of the Package Maintenance team, and of these docs as stated above, is to provide a set of resource and references that a package maintainer can follow as part of the maintenance and development of their package(s).  By provding these guidelines and recommendations, the hope is that projects can benefit from the combined experience of the NodeJS team and the community at large in way that facilities knowledge sharing and collaboration, in particular around things like tooling and automation, such that shared configurations and setups can reduce the barrier to entry and time needed for authors to setup, by providing that information first hand.
+
+> _In the spirit of open source, we are always open to contributions to help improve the docs now and over time, so if find anything missing or that could be improved, please don't hesitiate to open an or PR for the team._
+
+## Table of Contents
+1. [Licensing](./licensing.md)
+1. [Repository Settings (draft)](./drafts/repository-settings.md)
+1. [Continuous Integration / Delivery (draft)](./drafts/ci-cd-guidelines.md)
+1. [Workflows (draft)](./drafts/workflows.md)
+1. [Code of Conduct (draft)](./drafts/code-of-conduct.md)
+1. [Security (draft)](./drafts/security-guidelines.md)
+1. [Testing (draft)](./drafts/code-of-conduct.md)
+1. [Publishing Guidelines (draft)](./drafts/PUBLISH-GUIDELINES.md)
+1. [Versioning](./versioning.md)
+1. [Support (draft)](./drafts/PACKAGE-SUPPORT.md)
+
+## Notes / Assumptions
+As Node.js and most of the packages in the ecosystem are predominantly hosted on GitHub, there will be a natural leaning towards the features and capabilities provided by the GitHub platform references in these docs.  However, we understand that not one size fits all and will aim to provide recommendations that are well rounded and platform agnositc and from a voice of generatlity, emphasizing the value of the practice / recommendation.  In this way, we want to at least communicate the foundational elements such this information can and then be applied in whatever way fits a package's given workflow.  

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ By providing these guidelines and recommendations, the hope is that projects can
 > _In the spirit of open source, we are always open to contributions to help improve these docs, so if you find anything missing or that could be improved, please don't hesitiate to open an issue or PR for the team._
 
 
-## Notes / Assumptions
+## Notes and Assumptions
 As Node.js and most of the packages in the ecosystem are predominantly hosted on GitHub, there will be a natural leaning towards the features and capabilities provided by the GitHub platform referenced in these docs.  However, we understand that not one size fits all and so will aim to provide recommendations that are well rounded.  In this way, we want to at least communicate the foundational elements such that this information can and then be applied in whatever way fits a package's given workflow.  
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,16 @@
 
 This is the location for documentation, guides and other information developed by the package-maintenance team.  It is intended to provide as a set of resources and references for all package developers and maintainers. 
 
-## Goals and Objectives
-The goal of the Package Maintenance team, and of these docs as stated above, is to provide a set of resource and references that a package maintainer can follow as part of the maintenance and development of their package(s).  By provding these guidelines and recommendations, the hope is that projects can benefit from the combined experience of the NodeJS team and the community at large in way that facilities knowledge sharing and collaboration, in particular around things like tooling and automation, such that shared configurations and setups can reduce the barrier to entry and time needed for authors to setup, by providing that information first hand.
 
-> _In the spirit of open source, we are always open to contributions to help improve the docs now and over time, so if find anything missing or that could be improved, please don't hesitiate to open an or PR for the team._
+## Goals and Objectives
+By providing these guidelines and recommendations, the hope is that projects can benefit from the combined experience of the Node.js project and the community at large in a way that helps facilitate knowledge sharing and collaboration.  For example, documentation for topics like Continuous Integration can be used to share tooling configurations and setups that can help reduce the barrier to entry and time needed for authors to setup their own projects.
+
+> _In the spirit of open source, we are always open to contributions to help improve these docs, so if you find anything missing or that could be improved, please don't hesitiate to open an issue or PR for the team._
+
+
+## Notes / Assumptions
+As Node.js and most of the packages in the ecosystem are predominantly hosted on GitHub, there will be a natural leaning towards the features and capabilities provided by the GitHub platform referenced in these docs.  However, we understand that not one size fits all and so will aim to provide recommendations that are well rounded.  In this way, we want to at least communicate the foundational elements such that this information can and then be applied in whatever way fits a package's given workflow.  
+
 
 ## Table of Contents
 1. [Licensing](./licensing.md)
@@ -18,6 +24,4 @@ The goal of the Package Maintenance team, and of these docs as stated above, is 
 1. [Publishing Guidelines (draft)](./drafts/PUBLISH-GUIDELINES.md)
 1. [Versioning](./versioning.md)
 1. [Support (draft)](./drafts/PACKAGE-SUPPORT.md)
-
-## Notes / Assumptions
-As Node.js and most of the packages in the ecosystem are predominantly hosted on GitHub, there will be a natural leaning towards the features and capabilities provided by the GitHub platform references in these docs.  However, we understand that not one size fits all and will aim to provide recommendations that are well rounded and platform agnositc and from a voice of generatlity, emphasizing the value of the practice / recommendation.  In this way, we want to at least communicate the foundational elements such this information can and then be applied in whatever way fits a package's given workflow.  
+1. [Governance (draft)](./drafts/governance.md)

--- a/docs/drafts/code-of-conduct.md
+++ b/docs/drafts/code-of-conduct.md
@@ -1,0 +1,1 @@
+# Code of Conduct

--- a/docs/drafts/code-of-conduct.md
+++ b/docs/drafts/code-of-conduct.md
@@ -1,1 +1,3 @@
 # Code of Conduct
+
+TBD

--- a/docs/drafts/governance.md
+++ b/docs/drafts/governance.md
@@ -1,0 +1,32 @@
+Governance
+
+1. Intro / Goals
+  - provide consistency and predicatability in expectations for maintainer's and contributors
+  - add process and organization
+  - reduce overhead of common ceremonies through automation
+  - bring on, and engage with, contributors in an ongoing way
+  - security and dependability to the health of your package
+1. Assumptions
+  - github
+1. Repo Mainteance
+  - Branch Maintenance
+  - License
+  - Badges?
+1. Workflow
+  - Contributing.md
+  - Roadmap (pointing people in the right direction)
+  - Projects / Milestones / Labels (good first issue, pinned issues)
+  - Templates
+  - Automation (CI)
+     - linting
+     - testing
+     - ci-cd-guidelines
+  - Code Owners
+1. Code of Conduct
+1. Security
+  - Dependabot / Greenkeeper
+  - Lock files
+1. Release Management
+  - Publishing
+  - CITGM
+1. Support

--- a/docs/drafts/governance.md
+++ b/docs/drafts/governance.md
@@ -1,32 +1,3 @@
-Governance
+# Governance
 
-1. Intro / Goals
-  - provide consistency and predicatability in expectations for maintainer's and contributors
-  - add process and organization
-  - reduce overhead of common ceremonies through automation
-  - bring on, and engage with, contributors in an ongoing way
-  - security and dependability to the health of your package
-1. Assumptions
-  - github
-1. Repo Mainteance
-  - Branch Maintenance
-  - License
-  - Badges?
-1. Workflow
-  - Contributing.md
-  - Roadmap (pointing people in the right direction)
-  - Projects / Milestones / Labels (good first issue, pinned issues)
-  - Templates
-  - Automation (CI)
-     - linting
-     - testing
-     - ci-cd-guidelines
-  - Code Owners
-1. Code of Conduct
-1. Security
-  - Dependabot / Greenkeeper
-  - Lock files
-1. Release Management
-  - Publishing
-  - CITGM
-1. Support
+TBD

--- a/docs/drafts/repository-settings.md
+++ b/docs/drafts/repository-settings.md
@@ -1,0 +1,7 @@
+# Respository Settings
+
+Maintaining a repository should be something that can be configured to your project's preferred workflow and cadence.  Below are some recommendations and thoughts on various options that be enabled to facilite contributions and commits in a repository.
+
+## Managing Access
+
+## Branch Permissions

--- a/docs/drafts/repository-settings.md
+++ b/docs/drafts/repository-settings.md
@@ -1,7 +1,11 @@
 # Respository Settings
 
-Maintaining a repository should be something that can be configured to your project's preferred workflow and cadence.  Below are some recommendations and thoughts on various options that be enabled to facilite contributions and commits in a repository.
+Maintaining a repository should be something that can be configured to your project's preferred workflow and cadence through the code hosting platform of preference.  Below are some recommendations and thoughts on various options that be enabled to facilite contributions and commits in a repository.
 
 ## Managing Access
 
+
 ## Branch Permissions
+
+
+## Greenkeeper / Dependabot

--- a/docs/drafts/worflows.md
+++ b/docs/drafts/worflows.md
@@ -1,14 +1,22 @@
 # Workflows
 
+As contributions come into a project, establishing a clear roadmap for the project, expections for code quality and formatting, communication channels, and more, can make the workflows for both maintainers and contributors clear and help manage and set expectations.  Below are some considerations to keep in mind as you steer your projects.
 
+## Contributing Guidelines
 - Contributing.md
-- Roadmap (pointing people in the right direction)
+
+## Roadmap 
+- pointing contributor's in the right direction
+- defining priorities for the project
 - Projects / Milestones / Labels (good first issue, pinned issues)
-- Templates
-- Automation (CI)
-  - [ci-cd-guidelines (draft)](./drafts/ci-cd-guidelines.md)
-  - linting
-  - testing
-  - [testing-guidelines (draft)](./drafts/testing-guidelines.md)
-  - build matrix
-- Code Owners
+
+## Issue Templates
+- really good for bug reports
+- RFCs can be a good way to facilitate technical design discussions, project stewardship
+
+## Automation
+- linting
+testing
+- link out CI / CD guidelines
+
+##  Code Owners

--- a/docs/drafts/worflows.md
+++ b/docs/drafts/worflows.md
@@ -1,0 +1,14 @@
+# Workflows
+
+
+- Contributing.md
+- Roadmap (pointing people in the right direction)
+- Projects / Milestones / Labels (good first issue, pinned issues)
+- Templates
+- Automation (CI)
+  - [ci-cd-guidelines (draft)](./drafts/ci-cd-guidelines.md)
+  - linting
+  - testing
+  - [testing-guidelines (draft)](./drafts/testing-guidelines.md)
+  - build matrix
+- Code Owners

--- a/docs/drafts/workflows.md
+++ b/docs/drafts/workflows.md
@@ -16,7 +16,7 @@ As contributions come into a project, establishing a clear roadmap for the proje
 
 ## Automation
 - linting
-testing
+- testing
 - link out CI / CD guidelines
 
 ##  Code Owners

--- a/docs/drafts/workflows.md
+++ b/docs/drafts/workflows.md
@@ -3,7 +3,7 @@
 As contributions come into a project, establishing a clear roadmap for the project, expections for code quality and formatting, communication channels, and more, can make the workflows for both maintainers and contributors clear and help manage and set expectations.  Below are some considerations to keep in mind as you steer your projects.
 
 ## Contributing Guidelines
-- Contributing.md
+- Create a `Contributing.md` file containing contributing guidelines
 
 ## Roadmap 
 - pointing contributor's in the right direction


### PR DESCRIPTION
## Description
Coming out of the [2020-03-10](https://github.com/nodejs/package-maintenance/issues/324) meeting of the Package Maintenance team, on the topic of issue #309, the suggestion was that [this comment on the  suggestion of a Table of Contents](https://github.com/nodejs/package-maintenance/issues/309#issuecomment-590101809) for the docs in the repository be extracted out into its own PR.

## Summary of Changes
1. Updated the _docs/README.md_ to provide additional context and motivation on behalf of the team, and created a ToC that links to existing docs.
1. Created "stubs" for missing docs, that could become their own issues to track and can be authored independently and eventually promoted out of **draft** status.

## Questions / Considerations
Just around docs in general...
1. Is there a threshold for a doc moving out of draft status?
1. Would there be any value in having a general format / convention around docs in terms of authoring / organization / structure?