### PR TITLE
Add @jonchurch as a member

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -100,3 +100,4 @@
 * Owen Buckley ([@thescientist13](https://github.com/thescientist13))
 * Andrew Hughes ([@andrewhughes101](https://github.com/andrewhughes101))
 * Pranshu Srivastava ([@rexagod](https://github.com/rexagod))
+* Jon Church ([@jonchurch](https://github.com/jonchurch))


### PR DESCRIPTION
I've been involved in the Triage initiative in Express and find my OSS interests well aligned with this group's mission. 

I plan to continue to participate in the pilot efforts happening in Express, bring my feedback as a member of those efforts, and help to develop tools for package maintainers. 