### PR TITLE
request for help / getting started documentation for package authors and maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ about this initiative in the article:
   can make it easier for maintainers to manage multiple
   streams, and accept help from those who depend on their module.
 
+## For Maintainers
+
+Are you a maintainer of an open source project looking for help and resources maintaining your package and community?  To get you started,
+- Review [our growing set of documentation](https://github.com/nodejs/package-maintenance/blob/master/docs/README.md) around topics like CI / CD, testing, and governance
+
+### Feedback
+
+Want to provide feedback on your experiences as a maintainer?  Want to let us know what topic and tools you think would be helpful to pursue within this group?  Open a PR to fill out [this survey](https://github.com/nodejs/package-maintenance/blob/master/pilots/SURVEY.md) and the team will be sure to review and get in touch with you.
+
 ## Joining
 
 We encourage participation from members across the Node.js and JavaScript


### PR DESCRIPTION
resolves #372 

## Overview
Adds an initial first draft of a space in the README to speak directly to maintainers, whom are a direct audience we want to make sure we communicate the outcomes of our work as a group to.  This is just to get something going, and that ideally it would grow as more resources and tools become available, like **wiby** or **status-dashboard**.

## Questions / Thoughts 
1. Is this heading ok?  Is its position in the README ok?
1. Anything else we should to the list of resources at this time?