### PR TITLE
doc: fix testing guidelines link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ As Node.js and most of the packages in the ecosystem are predominantly hosted on
 1. [Workflows (draft)](./drafts/workflows.md)
 1. [Code of Conduct (draft)](./drafts/code-of-conduct.md)
 1. [Security (draft)](./drafts/security-guidelines.md)
-1. [Testing (draft)](./drafts/code-of-conduct.md)
+1. [Testing (draft)](./drafts/testing-guidelines.md)
 1. [Publishing Guidelines (draft)](./drafts/PUBLISH-GUIDELINES.md)
 1. [Versioning](./versioning.md)
 1. [Support](./PACKAGE-SUPPORT.md)


### PR DESCRIPTION
This small RP fixes link to testing guidelines in docs README