### PR TITLE
docs: PR landing, with outstanding reviews

### DIFF
--- a/Governance.md
+++ b/Governance.md
@@ -110,7 +110,7 @@ is for there to be:
 - In the event there are 4 approvals but existing pending reviews still exist a countdown of 21 days will start. During
 the countdown period every possible effort must be made to contact the reviewer. If the reviewer cannot be 
 contacted to review the changes within the countdown period, and their requested changes are believed to be addressed, the PR may be landed. This rule is not intended to circumvent
-the policy of consensus when it is known that concensus has not been reached.
+the policy of consensus when it is known that consensus has not been reached.
 
 All PRs shall follow the [contributions policy](CONTRIBUTING.md)
 

--- a/Governance.md
+++ b/Governance.md
@@ -107,6 +107,10 @@ is for there to be:
 - At least 4 approvals from regular members other than the author of the PR
 - No blocking reviews
 - 7 day period from the 4th approval to merging
+- In the event there are 4 approvals but existing pending reviews still exist a countdown of 21 days will start. During
+the countdown period every possible effort must be made to contact the reviewer. If the reviewer cannot be 
+contacted to review the changes within the countdown period the PR may be landed. This rule is not intended to circumvent
+the policy of consensus when it is known that concensus has not been reached.
 
 All PRs shall follow the [contributions policy](CONTRIBUTING.md)
 

--- a/Governance.md
+++ b/Governance.md
@@ -109,7 +109,7 @@ is for there to be:
 - 7 day period from the 4th approval to merging
 - In the event there are 4 approvals but existing pending reviews still exist a countdown of 21 days will start. During
 the countdown period every possible effort must be made to contact the reviewer. If the reviewer cannot be 
-contacted to review the changes within the countdown period the PR may be landed. This rule is not intended to circumvent
+contacted to review the changes within the countdown period, and their requested changes are believed to be addressed, the PR may be landed. This rule is not intended to circumvent
 the policy of consensus when it is known that concensus has not been reached.
 
 All PRs shall follow the [contributions policy](CONTRIBUTING.md)


### PR DESCRIPTION
After discussions with @dominykas et al during the package maintenance team meeting it was requested that a change was needed in our governance to handle the situation of PR being blocked when the reviewer had not responded for reasonable period of time.
The change being made is in no way an attempt to work around consensus but an attempt to handle cases of PRs being well reviewed by many participants but not being able to land due to the outstanding reviews that have in all likelihood been addressed.