### PR TITLE
promote security-guidelines from draft

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ As Node.js and most of the packages in the ecosystem are predominantly hosted on
 1. [Continuous Integration / Delivery (draft)](./drafts/ci-cd-guidelines.md)
 1. [Workflows (draft)](./drafts/workflows.md)
 1. [Code of Conduct (draft)](./drafts/code-of-conduct.md)
-1. [Security (draft)](./drafts/security-guidelines.md)
+1. [Security](./security-guidelines.md)
 1. [Testing](./testing-guidelines.md)
 1. [Publishing Guidelines (draft)](./drafts/PUBLISH-GUIDELINES.md)
 1. [Dependency management](./dependency-management-guidelines.md)

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -30,10 +30,7 @@ the public issue tracker advice should make it clear what is in bounds.
 
 Project security policy should describe a process for reporting vulnerabilities. It is strongly encouraged that the reporting process is confidential to allow maintainers to triage and resolve the vulnerability in private before disclosing it to the public.
 
-Here are several common ways of reporting vulnerabilities:
-
-1. Designated email address, e.g. `security@example.com`.
-1. [Node.js Ecosystem Security WG](https://github.com/nodejs/security-wg) responsible disclosure program on [HackerOne](https://hackerone.com/nodejs-ecosystem).
+A common way of reporting vulnerabilities is through a designated email address, e.g. `security@example.com`.
 
 The policy should clearly specify when confidential reporting is not supported and generally available bug tracking system should be used.
 
@@ -48,8 +45,6 @@ Here are several alternative ways to disclose a vulnerability:
 1. [Report a vulnerability to npm](https://docs.npmjs.com/reporting-malware-in-an-npm-package).
 1. Submit a pull request to [vulnerability database](https://github.com/nodejs/security-wg/blob/master/processes/vuln_db.md) maintained by [Node.js Ecosystem Security WG](https://github.com/nodejs/security-wg).
 
-Note that vulnerabilities reported to the responsible disclosure program on [HackerOne](https://hackerone.com/nodejs-ecosystem) will be automatically disclosed by HackerOne staff and the Ecosystem Security WG triage team members.
-
 ### Collaboration between maintainers and reporters
 
 The policy should recommend that maintainers and reporters collaborate to ensure the accuracy of the vulnerability report and the security advisory. In particular, information such as: 
@@ -62,7 +57,7 @@ The policy should recommend that maintainers and reporters collaborate to ensure
 
 should be established in collaboration between maintainers and the reporter.
 
-If possible, the policy should recommend means of communication between all parties working towards responsible disclosure. [Maintainer advisories on GitHub](https://help.github.com/en/github/managing-security-vulnerabilities/creating-a-maintainer-security-advisory) and [the responsible disclosure program on HackerOne](https://hackerone.com/nodejs-ecosystem) are recommended to ensure the confidentiality.
+If possible, the policy should recommend means of communication between all parties working towards responsible disclosure. See [Maintainer advisories on GitHub](https://help.github.com/en/github/managing-security-vulnerabilities/creating-a-maintainer-security-advisory)
 
 ### Releasing security patches
 

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -43,7 +43,6 @@ The recommended approach is to [create a maintainer advisory on GitHub](https://
 Here are several alternative ways to disclose a vulnerability:
 
 1. [Report a vulnerability to npm](https://docs.npmjs.com/reporting-malware-in-an-npm-package).
-1. Submit a pull request to [vulnerability database](https://github.com/nodejs/security-wg/blob/master/processes/vuln_db.md) maintained by [Node.js Ecosystem Security WG](https://github.com/nodejs/security-wg).
 
 ### Collaboration between maintainers and reporters
 

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -45,7 +45,7 @@ The recommended approach is to [create a maintainer advisory on GitHub](https://
 
 Here are several alternative ways to disclose a vulnerability:
 
-1. [Report a vulnerability to npm](https://www.npmjs.com/advisories/report).
+1. [Report a vulnerability to npm](https://docs.npmjs.com/reporting-malware-in-an-npm-package).
 1. Submit a pull request to [vulnerability database](https://github.com/nodejs/security-wg/blob/master/processes/vuln_db.md) maintained by [Node.js Ecosystem Security WG](https://github.com/nodejs/security-wg).
 
 Note that vulnerabilities reported to the responsible disclosure program on [HackerOne](https://hackerone.com/nodejs-ecosystem) will be automatically disclosed by HackerOne staff and the Ecosystem Security WG triage team members.


### PR DESCRIPTION
Addresses #343 

### TBD

There are several [HackerOne](https://hackerone.com/nodejs-ecosystem?type=team) links to a page that reads:

> The Node.js Ecosystem program is no longer accepting reports.
Please report any potential vulnerabilities to the respective Node.js Ecosystem disclosure channel.
This page will remain public as a thank you to the community for your contributions!

Not sure if all these links need to remain documented in this file.