### PR TITLE
Need to leave that effort in favor of net wide nodejs deprecation via…

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -25,7 +25,6 @@
 * Karan Sapolia ([@karansapolia](https://github.com/karansapolia))
 * Andrew Kuzmenko ([@andrewkuzmenko](https://github.com/andrewkuzmenko))
 * Petr Grishin ([@petrgrishin](https://github.com/petrgrishin))
-* Frank Lemanschik ([@frank-dspeed](https://github.com/frank-dspeed))
 * Nardyuzhev Vadim ([@vadinN](https://github.com/vadinN))
 * Hassan Sani ([@inidaname](https://github.com/inidaname))
 * Sathish Gajendran ([@sathishgajendran](https://github.com/sathishgajendran))


### PR DESCRIPTION
… chromium modular as a platform it self

Need to leave that effort in favor of net wide nodejs deprecation via chromium modular as a platform it self

see: 
- https://github.com/nodejs/package-maintenance/issues/547#event-8006766334
- https://github.com/nodejs/package-maintenance/issues/542#issuecomment-1345345127

It makes out of my view no sense to keep NPM and NodeJS Compat when the community is blocking so i need to deprecate nodejs via offering a chromium cli which i in fact have at hands to replace nodejs via a modular chromium build it self i mainly work on the chromium project anyway. 