### PR TITLE
Add @bjohansebas to administrative members

### DIFF
--- a/ADMINISTRATIVE-MEMBERS.md
+++ b/ADMINISTRATIVE-MEMBERS.md
@@ -5,6 +5,7 @@ See [how to join](https://github.com/nodejs/package-maintenance#how-to-join) and
 * Bethany Griggs ([@BethGriggs](https://github.com/bethgriggs))
 * Jordan Harband ([@ljharb](https://github.com/ljharb))
 * Wes Todd ([@wesleytodd](https://github.com/wesleytodd))
+* Sebastian Beltran ([@bjohansebas](https://github.com/bjohansebas))
 
 # Emeritus Administrative Members
 


### PR DESCRIPTION
As I was discussing with @wesleytodd  @BethGriggs  @ljharb, I’d like to become an administrative member to help with all those matters and assist in leading this group, so I’m opening this to make the nomination official.

cc: @nodejs/package-maintenance 